### PR TITLE
Inject sidekiq:stop after deploy:reverted

### DIFF
--- a/lib/capistrano/tasks/sidekiq.rake
+++ b/lib/capistrano/tasks/sidekiq.rake
@@ -8,6 +8,7 @@ namespace :sidekiq do
   task :add_default_hooks do
     after 'deploy:starting', 'sidekiq:quiet' if Rake::Task.task_defined?('sidekiq:quiet')
     after 'deploy:updated', 'sidekiq:stop'
+    after 'deploy:reverted', 'sidekiq:stop'
     after 'deploy:published', 'sidekiq:start'
     after 'deploy:failed', 'sidekiq:restart'
   end


### PR DESCRIPTION
In order to make the `deploy:rollback` command work with sidekiq, we need to add a hook into the `deploy:reverted` task, which runs on rollback instead of `deploy:updated`.